### PR TITLE
Fix incorrect names docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ In your Cargo.toml add the following:
 
 ```toml
 [dependencies]
-fuzzy_matcher = "*"
+fuzzy-matcher = "*"
 ```
 
 Here are some code example:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ fuzzy-matcher = "*"
 Here are some code example:
 
 ```rust
-use fuzzy_matcher::skim::{fuzzy_match, fuzzy_matcher};
+use fuzzy_matcher::skim::{fuzzy_match, fuzzy_indices};
 
 assert_eq!(None, fuzzy_match("abc", "abx"));
 assert!(fuzzy_match("axbycz", "abc").is_some());


### PR DESCRIPTION
Fixes two naming errors in the docs, make it easier for the next developer starting out with the library.