### PR TITLE
WIP: Tune separator bonus

### DIFF
--- a/src/skim.rs
+++ b/src/skim.rs
@@ -332,5 +332,6 @@ mod tests {
         assert_order("ast", &["ast", "AST", "INT_FAST16_MAX"]);
         // score(PRINT) > kMinScore
         assert_order("Int", &["int", "INT", "PRINT"]);
+        assert_order("skim", &["Code/External/skim", "Code/External/skim/man"]);
     }
 }


### PR DESCRIPTION
Reproduction of https://github.com/lotabout/skim/issues/213.

The algorithm seems to score `ski_/m` higher than `skim`. I have a hunch it is a bug between adding adjacent bonus (+10).

```rust
// test output
60: "Code/External/[s][k][i][m]"
62: "Code/External/[s][k][i]m/[m]an"
```

Any pointers @lotabout?