### PR TITLE
Make public-facing type aliases public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,14 +3,14 @@ pub mod skim;
 mod util;
 
 #[cfg(not(feature = "compact"))]
-type IndexType = usize;
+pub type IndexType = usize;
 #[cfg(not(feature = "compact"))]
-type ScoreType = i64;
+pub type ScoreType = i64;
 
 #[cfg(feature = "compact")]
-type IndexType = u32;
+pub type IndexType = u32;
 #[cfg(feature = "compact")]
-type ScoreType = i32;
+pub type ScoreType = i32;
 
 pub trait FuzzyMatcher: Send + Sync {
     /// fuzzy match choice with pattern, and return the score & matched indices of characters


### PR DESCRIPTION
Hey there,

First time using fuzzy-matcher and I noticed that `ScoreType` isn't `pub`. This is a bit of a pain if you want to store the scores anywhere, as it forces the user to use the explicit `i64` type. This is an ergonomics, usability, and readability issue.

Enabling or disabling the `"compact"` feature will cause compilation errors if the user is storing score results anywhere. It also makes upgrading the crate version riskier for users, as the backing type of `ScoreType` or `IndexType` can change.

Afaik there's no downside to making these types `pub`, please correct me if I'm wrong.

Builds OK.
Was not able to run tests, could not compile `termion` since I am on Windows.