### PR TITLE
[skim v2] avoid panic when cache is disabled

### DIFF
--- a/src/skim.rs
+++ b/src/skim.rs
@@ -931,9 +931,9 @@ impl SkimMatcherV2 {
 
         if !self.use_cache {
             // drop the allocated memory
-            self.m_cache.get().map(|cell| cell.replace(vec![]));
-            self.c_cache.get().map(|cell| cell.replace(vec![]));
-            self.p_cache.get().map(|cell| cell.replace(vec![]));
+            cell.replace(vec![]);
+            cell.replace(vec![]);
+            cell.replace(vec![]);
         }
 
         Some((m_score as ScoreType, positions))


### PR DESCRIPTION
when i set `.use_cache(false)` i got a panic:
```
thread 'my-thread' panicked at /HOME/.cargo/registry/src/index.crates.io-6f17d22bba15001f/fuzzy-matcher-0.3.7/src/skim.rs:932:48:
already borrowed: BorrowMutError
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

i think that's because `m` is already an owned borrow (line 837), and same with `choice_chars` and `pattern_chars`, all of which are still owned when we get to this `if`

disclaimer: i didn't actually test this change (i did it in github's inline editor lmao). i can test later if desired