### PR TITLE
Fix panic when turning off `use_cache`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: Build & Test
 on:
-  push:
   pull_request:
+  push:
     branches:
     - master
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: Build & Test
 on:
-  pull_request:
   push:
+  pull_request:
     branches:
     - master
 

--- a/tests/use_cache.rs
+++ b/tests/use_cache.rs
@@ -1,0 +1,27 @@
+use fuzzy_matcher::FuzzyMatcher;
+
+#[test]
+fn use_cache_off_works() {
+    let options = [1, 2, 3, 4, 5, 6, 7, 11].map(|x| x.to_string());
+
+    let matcher = fuzzy_matcher::skim::SkimMatcherV2::default().use_cache(false);
+    for matching in options
+        .iter()
+        .filter_map(|n| matcher.fuzzy_match(n.as_str(), "1").map(|score| (n, score)))
+    {
+        println!("{matching:?}");
+    }
+}
+
+#[test]
+fn use_cache_on_works() {
+    let options = [1, 2, 3, 4, 5, 6, 7, 11].map(|x| x.to_string());
+
+    let matcher = fuzzy_matcher::skim::SkimMatcherV2::default().use_cache(true);
+    for matching in options
+        .iter()
+        .filter_map(|n| matcher.fuzzy_match(n.as_str(), "1").map(|score| (n, score)))
+    {
+        println!("{matching:?}");
+    }
+}


### PR DESCRIPTION
The main problem with the old code was that all of the cache RefCells
were held for too long because of the huge scope of the `fuzzy`
function. The problem was already solved by just wrapping some of the
code with an extra scope `{` + `}`. However I chose to refactor a bit
and split the old function into 3 new ones:

- `simple_match` - was already there
- `sophisticated_match` - basically the else case of `simple_match`
- `fuzzy_inner` - a function just for the control flow of the other
  function. This also handles the cache invalidation

This should supersede the pull request https://github.com/lotabout/fuzzy-matcher/pull/20