### PR TITLE
bump termion dev-dependency from 1.5.1 to 4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,4 @@ compact = []
 thread_local = "1.0.0"
 
 [dev-dependencies]
-termion = "1.5.1"
+termion = "4"


### PR DESCRIPTION
fuzzy-matcher is not affected by API changes between termion v1 and v4, so this is a simple change.